### PR TITLE
feat: env 생성 및 로그인 임시 코드 작성 (수정 필요)

### DIFF
--- a/src/js/common.js
+++ b/src/js/common.js
@@ -1,12 +1,12 @@
 export const customFetch = async (url, option) => {
   try {
     const { method, body } = option;
-    const token = localStorage.getItem("token");
+    const token = localStorage.getItem("accessToken");
     const headers = {
       "Content-Type": "application/json",
       Authorization: token ? `Bearer ${token}` : "",
     };
-    const res = await fetch(url, {
+    const res = await fetch(`${import.meta.env.VITE_BACKEND_URL}${url}`, {
       method,
       headers,
       body: JSON.stringify(body),

--- a/src/js/login.js
+++ b/src/js/login.js
@@ -32,13 +32,10 @@ document.addEventListener("DOMContentLoaded", () => {
     const username = event.target.username.value;
     const password = event.target.password.value;
 
-    const res = await customFetch(
-      "http://114.205.33.109:9090/api/auth/signin",
-      {
-        method: "POST",
-        body: { name: username, password },
-      }
-    );
+    const res = await customFetch("/api/auth/signin", {
+      method: "POST",
+      body: { name: username, password },
+    });
     if (res.error) {
       alert("요청 중 에러가 발생했습니다.");
       return;
@@ -46,6 +43,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     if (res.ok) {
       console.log(res.data);
+      // cookie 설정
     } else {
       alert("ID 또는 PW가 잘못됐습니다.");
       // loginModal.classList.add("hidden");

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,9 +1,16 @@
 import { resolve } from "node:path";
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
+
 const root = resolve(__dirname, "src");
 const publicDir = resolve(__dirname, "public");
-export default defineConfig({
-  root,
-  publicDir,
-  appType: "mpa",
-});
+
+export default ({ mode }) => {
+  process.env = { ...process.env, ...loadEnv(mode, process.cwd()) };
+
+  return defineConfig({
+    root,
+    publicDir,
+    envDir: ".env",
+    appType: "mpa",
+  });
+};


### PR DESCRIPTION
현재 백엔드 구조 변경할 예정이라 조금 코드도 달라질거고 로그인 후에 accessToken과 refreshToken cookies에 설정해야합니다.
fetch할 때는 자동 전송을 이용할 것 같습니다. (refreshToken을 httpOnly로 활용할 것이기 때문에)